### PR TITLE
Do not modify original rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test-packages/base-rules-conflict/

--- a/lib/base.js
+++ b/lib/base.js
@@ -9,7 +9,7 @@ const { Linter } = require("eslint");
 const { klona } = require("klona/lite");
 
 module.exports.buildRule = ({ baseRuleName, description, omitFirstOption, getESLintOption }) => {
-  const jsBaseRule = new Linter().getRules().get(baseRuleName);
+  const jsBaseRule = klona(new Linter().getRules().get(baseRuleName));
 
   // Remove first option
   if (omitFirstOption !== false) {
@@ -37,7 +37,7 @@ module.exports.buildRule = ({ baseRuleName, description, omitFirstOption, getESL
 
       if (filename.endsWith(".ts")) {
         const { rules } = require("@typescript-eslint/eslint-plugin");
-        baseRule = rules[baseRuleName] ? rules[baseRuleName] : jsBaseRule;
+        baseRule = rules[baseRuleName] ? klona(rules[baseRuleName]) : jsBaseRule;
       } else {
         baseRule = jsBaseRule;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-editorconfig",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "An ESLint plugin to enforce EditorConfig rules",
   "main": "main.js",
   "scripts": {

--- a/test-packages/base-rules-conflict/.eslintrc.js
+++ b/test-packages/base-rules-conflict/.eslintrc.js
@@ -1,0 +1,30 @@
+"use strict";
+
+module.exports = {
+  root: true,
+
+  env: {
+    es6: true,
+    node: true,
+  },
+  parserOptions: {
+    ecmaVersion:  2020,
+  },
+  plugins: [ "editorconfig" ],
+  rules: {
+    "unicode-bom": [ "error", "never" ],
+    "eol-last": [ "error", "always" ],
+    indent: [ "error", 2, {
+      SwitchCase: 1,
+    }],
+    "linebreak-style": [ "error", "unix" ],
+    "no-trailing-spaces": [ "error", {
+      skipBlankLines: false,
+    }],
+    "editorconfig/charset": "error",
+    "editorconfig/eol-last": "error",
+    "editorconfig/indent": "error",
+    "editorconfig/linebreak-style": "error",
+    "editorconfig/no-trailing-spaces": "error",
+  },
+};

--- a/test-packages/base-rules-conflict/main.js
+++ b/test-packages/base-rules-conflict/main.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const foo = 0;
+
+console.log(foo);

--- a/test-packages/base-rules-conflict/package.json
+++ b/test-packages/base-rules-conflict/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@phanect/test-package-base-rules-conflict",
+  "version": "1.0.0",
+  "description": "a test package",
+  "author": "Jumpei Ogawa <phanective@gmail.com>",
+  "license": "MIT",
+  "private": true,
+  "main": "main.js",
+  "scripts": {
+    "lint": "eslint . --ext=.js,.ts",
+    "test": "npm run lint"
+  }
+}


### PR DESCRIPTION
Currently, eslint-plugin-editorconfig modifies the rule object received from `new Linter().getRules().get(baseRuleName)` directly.
By modifying the object, it modifies original rule object.

Therefore, if the original rule is used anywhere (e.g. in extending eslint-config-* packages), it causes error.

This PR fixes the error by cloning the base rule object before modifying it.

Closes #38