### PR TITLE
Allow fallback options in case editorconfig is not present

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -3,18 +3,12 @@
  * @author Jumpei Ogawa
  */
 "use strict";
-
 const editorconfig = require("editorconfig");
 const { Linter } = require("eslint");
 const { klona } = require("klona/lite");
 
-module.exports.buildRule = ({ baseRuleName, description, omitFirstOption, getESLintOption }) => {
+module.exports.buildRule = ({ baseRuleName, description, getESLintOption }) => {
   const jsBaseRule = klona(new Linter().getRules().get(baseRuleName));
-
-  // Remove first option
-  if (omitFirstOption !== false) {
-    jsBaseRule.meta.schema.shift();
-  }
 
   return {
     meta: {
@@ -43,10 +37,13 @@ module.exports.buildRule = ({ baseRuleName, description, omitFirstOption, getESL
       }
 
       if (eslintOption) {
-        _context.options.unshift(eslintOption);
+        // Overwrite first option if found in editorconfig
+        _context.options[0] = eslintOption
       }
 
-      return enabled ? baseRule.create(_context) : {};
+
+      // Only enable rule when option is specified in .editorconfig or .eslintrc
+      return enabled || (enabled !== false && _context.options.length > 0) ? baseRule.create(_context) : {};
     },
   };
 };

--- a/lib/rules/charset.js
+++ b/lib/rules/charset.js
@@ -11,7 +11,7 @@ module.exports = buildRule({
     } else if (ecParams.charset === "utf-8-bom") {
       return { enabled: true, eslintOption: "always" };
     } else {
-      return { enabled: false };
+      return {};
     }
   },
 });

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -11,7 +11,7 @@ module.exports = buildRule({
     } else if (ecParams.insert_final_newline === false) {
       return { enabled: true, eslintOption: "never" };
     } else {
-      return { enabled: false };
+      return {};
     }
   },
 });

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -11,7 +11,7 @@ module.exports = buildRule({
     } else if (ecParams.indent_style === "tab") {
       return { enabled: true, eslintOption: "tab" };
     } else {
-      return { enabled: false };
+      return {};
     }
   },
 });

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -11,7 +11,7 @@ module.exports = buildRule({
     } else if (ecParams.end_of_line === "crlf") {
       return { enabled: true, eslintOption: "windows" };
     } else {
-      return { enabled: false };
+      return {};
     }
   },
 });

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -5,6 +5,5 @@ const { buildRule } = require("../base");
 module.exports = buildRule({
   baseRuleName: "no-trailing-spaces",
   description: "Enforce EditorConfig rules for trailing spaces",
-  omitFirstOption: false,
   getESLintOption: (ecParams) => ({ enabled: ecParams.trim_trailing_whitespace }),
 });

--- a/tests/lib/rules/editorconfig-ts.js
+++ b/tests/lib/rules/editorconfig-ts.js
@@ -59,7 +59,7 @@ ruleTester.run("editorconfig/indent (typescript)", require("../../../lib/rules/i
     {
       // Passing Options (indent)
       filename: path.join(__dirname, "../../configs/default/target.ts"),
-      options: [{ VariableDeclarator: { var: 2, let: 2, const: 3 }}],
+      options: [0, { VariableDeclarator: { var: 2, let: 2, const: 3 }}],
       code: `'use strict';
 const foo: string = 'foo',
       bar: string = 'bar',
@@ -99,7 +99,7 @@ const foo: number = 0;
     {
       // Passing Options
       filename: path.join(__dirname, "../../configs/default/target.ts"),
-      options: [{ VariableDeclarator: { var: 2, let: 2, const: 3 }}],
+      options: [0, { VariableDeclarator: { var: 2, let: 2, const: 3 }}],
       code: `'use strict';
 const foo: string = 'foo',
   bar: string = 'bar';

--- a/tests/lib/rules/editorconfig.js
+++ b/tests/lib/rules/editorconfig.js
@@ -54,7 +54,7 @@ ruleTester.run("editorconfig/indent (javascript)", require("../../../lib/rules/i
     {
       // Passing Options (indent)
       filename: path.join(__dirname, "../../configs/default/target.js"),
-      options: [{ VariableDeclarator: { var: 2, let: 2, const: 3 }}],
+      options: [0, { VariableDeclarator: { var: 2, let: 2, const: 3 }}],
       code: `'use strict';
 const foo = 'foo',
       bar = 'bar',
@@ -94,7 +94,7 @@ const foo = 0;
     {
       // Passing Options
       filename: path.join(__dirname, "../../configs/default/target.js"),
-      options: [{ VariableDeclarator: { var: 2, let: 2, const: 3 }}],
+      options: [0, { VariableDeclarator: { var: 2, let: 2, const: 3 }}],
       code: `'use strict';
 const foo = 'foo',
   bar = 'bar';


### PR DESCRIPTION
This allows using rule options as a fallback in case the .editorconfig file is not present.
Rules are still disabled when no options are specified in .eslintrc (e.g. only "error"), however when options are specified they are used as a fallback.

E.g. the following configuration can be used to to lint all rules with the following defaults in case of no editorconfig:
```json
"editorconfig/charset": ["error", "never"],
"editorconfig/eol-last": ["error", "always"],
"editorconfig/indent": ["error", 4],
"editorconfig/linebreak-style": ["error", "unix"],
"editorconfig/no-trailing-spaces": ["error", {}],
```

When the editorconfig is present the default options are overridden but still allows all sub-options from the eslint base rule:
```json
"editorconfig/indent": [ "error", 2, { 
  "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } 
}],
"editorconfig/no-trailing-spaces": ["error", { "skipBlankLines": true }]
```

This PR can be further simplified by always falling back to the eslint defaults, which I think makes more sense as the rules can be turned off by the user if they should not be enforced.