### PR TITLE
[BREAKING] Maintenance for CI to prepare for Node.js & ESLint upgrade on next major release of this plugin

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,11 +20,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14
-          - 16
           - 18
           - 20
-          - 21
+          - 22
         eslint-version:
           - 8
     env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,8 @@
 name: GitHub Actions
 
 on:
+  schedule:
+    - cron: "8 11 * * 5" # At 11:08 on Friday
   pull_request:
     branches:
       - main

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - run: npm install # not `npm ci` since there is no package-lock.json in this project
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,6 +25,10 @@ jobs:
           - 18
           - 20
           - 21
+        eslint-version:
+          - 8
+    env:
+      ESLINT_VERSION: ${{ matrix.eslint-version }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-.circleci/
+.github/
 .editorconfig
 .eslintrc.js
 node_modules/

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ An ESLint plugin to enforce EditorConfig rules
 
 - ESLint v8
   - ESLint v9 and flat config support is not ready yet. Even if you use legacy .eslintrc.\*, it does not work on v9. Sorry! :pray:
-- Node.js v{16, 18, 20}
-  - While not officially supported, also tested on v14 and v21. v14 support will be dropped on next major release. v21 support will be dropped when it reaches EOL and without major update of eslint-plugin-editorconfig.
+- Node.js v{18, 20, 22}
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An ESLint plugin to enforce EditorConfig rules
 
-[![CircleCI](https://circleci.com/gh/phanect/eslint-plugin-editorconfig.svg?style=svg)](https://circleci.com/gh/phanect/eslint-plugin-editorconfig) [![NPM Version](https://img.shields.io/npm/v/eslint-plugin-editorconfig.svg)](https://npmjs.org/package/eslint-plugin-editorconfig)
+[![GitHub Actions Status](https://github.com/phanect/eslint-plugin-editorconfig/actions/workflows/actions.yml/badge.svg)](https://github.com/phanect/eslint-plugin-editorconfig/actions/workflows/actions.yml) [![NPM Version](https://img.shields.io/npm/v/eslint-plugin-editorconfig.svg)](https://npmjs.org/package/eslint-plugin-editorconfig)
 
 ## Requirements
 

--- a/test-packages/test.sh
+++ b/test-packages/test.sh
@@ -6,6 +6,11 @@ TEST_PKGS_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 PROJECT_ROOT="$(realpath "${TEST_PKGS_DIR}/..")"
 TMP="$(mktemp --directory)"
 
+# To run tests on local machine
+if [[ -z "${ESLINT_VERSION:-}" ]]; then
+  ESLINT_VERSION=8
+fi
+
 cd "${PROJECT_ROOT}"
 PACKAGE="$(npm pack .)"
 
@@ -15,31 +20,29 @@ git clean -Xd --force
 # If you test without copying, test package is affected by node_modules in the project root
 cp --recursive "${TEST_PKGS_DIR}" "${TMP}/"
 
-for ESLINT_VERSION in "7" "8"; do
-  for PKGDIR in $(find "${TMP}/test-packages/success/" -maxdepth 1 -type d ! -path "${TMP}/test-packages/success/"); do
-    cd "${PKGDIR}"
-    npm install
-    npm install --save-dev "eslint@${ESLINT_VERSION}" "${PROJECT_ROOT}/${PACKAGE}"
-    npm run lint
-  done
+for PKGDIR in $(find "${TMP}/test-packages/success/" -maxdepth 1 -type d ! -path "${TMP}/test-packages/success/"); do
+  cd "${PKGDIR}"
+  npm install
+  npm install --save-dev "eslint@${ESLINT_VERSION}" "${PROJECT_ROOT}/${PACKAGE}"
+  npm run lint
+done
 
-  for PKGDIR in $(find "${TMP}/test-packages/failure/" -maxdepth 1 -type d ! -path "${TMP}/test-packages/failure/"); do
-    cd "${PKGDIR}"
-    npm install
-    npm install --save-dev "eslint@${ESLINT_VERSION}" "${PROJECT_ROOT}/${PACKAGE}"
+for PKGDIR in $(find "${TMP}/test-packages/failure/" -maxdepth 1 -type d ! -path "${TMP}/test-packages/failure/"); do
+  cd "${PKGDIR}"
+  npm install
+  npm install --save-dev "eslint@${ESLINT_VERSION}" "${PROJECT_ROOT}/${PACKAGE}"
 
-    if [[ "${PKGDIR}" = "${TMP}/test-packages/failure/missing-ts-eslint" ]]; then
-      # skip if Node.js version == 14.x
-      if [[ -n "$(node --version | grep '^v14\.')" ]]; then
-        continue
-      fi
-
-      if [[ -z "$((npm run lint 2>&1) | grep "eslint-plugin-editorconfig requires typescript and @typescript-eslint/eslint-plugin to lint \*.ts files. Run \`npm install typescript @typescript-eslint/eslint-plugin\`.")" ]]; then
-        echo "Error message is not shown properly when @typescript-eslint/eslint-plugin is missing" >&2
-        echo "ESLint's error message:"
-        npm run lint
-        exit 1
-      fi
+  if [[ "${PKGDIR}" = "${TMP}/test-packages/failure/missing-ts-eslint" ]]; then
+    # skip if Node.js version == 14.x
+    if [[ -n "$(node --version | grep '^v14\.')" ]]; then
+      continue
     fi
-  done
+
+    if [[ -z "$((npm run lint 2>&1) | grep "eslint-plugin-editorconfig requires typescript and @typescript-eslint/eslint-plugin to lint \*.ts files. Run \`npm install typescript @typescript-eslint/eslint-plugin\`.")" ]]; then
+      echo "Error message is not shown properly when @typescript-eslint/eslint-plugin is missing" >&2
+      echo "ESLint's error message:"
+      npm run lint
+      exit 1
+    fi
+  fi
 done


### PR DESCRIPTION
This PR includes **breaking change**: drop support for Node.js v14, v16, v21.